### PR TITLE
Correct LispAtom -> LispList, parsing line 231

### DIFF
--- a/docs/2_parsing.md
+++ b/docs/2_parsing.md
@@ -228,7 +228,7 @@ module LispTypes
 
 type LispVal =
     | LispAtom of string
-    | ListAtom of List<LispVal>
+    | ListList of List<LispVal>
     | LispDottedList of List<LispVal> * LispVal
     | LispNumber of int64
     | LispString of string


### PR DESCRIPTION
In the chapter on Parsing under "Refactor the code", the type LispVal had LispAtom both as first and second constructor, where LispList were used earlier.